### PR TITLE
fix: make pretty-hydra optional

### DIFF
--- a/sdml-mode-hydra.el
+++ b/sdml-mode-hydra.el
@@ -1,7 +1,7 @@
 
 (require 'sdml-mode)
 (require 'sdml-mode-ctags)
-(require 'pretty-hydra)
+(require 'pretty-hydra nil t)
 
 (cond
  ((featurep 'pretty-hydra)


### PR DESCRIPTION
Previously, there is an error if pretty-hydra is not installed.